### PR TITLE
execute all commands into a sub shell

### DIFF
--- a/src/via.ts
+++ b/src/via.ts
@@ -89,7 +89,7 @@ const projectWideActions = ["start", "stop"]
 async function runCommand(cmd: string, cwd: string) {
   console.log(`Running ${cmd} in ${cwd}`)
   const p = Deno.run({
-    cmd: cmd.split(" "),
+    cmd: ['sh', '-c', cmd],
     cwd,
   });
   await p.status()


### PR DESCRIPTION
* this allows a more complex actions by using shell features like && || &
* it does not split up the action-string by spaces which could lead to non functional commands (if quotes are involved)

I think this should do trick mentioned in #2 

I've tested this without any issue, but i think it would be better if you (@Sopamo ) could test it as well