### PR TITLE
Feature/passthrough arguments to actions

### DIFF
--- a/src/cliCommander.ts
+++ b/src/cliCommander.ts
@@ -77,7 +77,7 @@ export const createViaCommander = (config: ViaConfig, currentProjectName: Projec
       // if arguments are passed in here, the arguments does not match any other command
       // in this case we just print the help text
       if (args.length === 0 && 'version' in options && options.version === undefined) {
-        console.log('0.0.1', options);
+        console.log('0.0.1');
       } else {
         cmd._helpAndError()
       }

--- a/src/cliCommander.ts
+++ b/src/cliCommander.ts
@@ -61,13 +61,27 @@ const createServiceCommands = (serviceCommander: Commander, serviceConfig: Servi
         .command(actionName)
         .description('<Action>')
         .action(runAction(actionCommand, serviceConfig))
+        .allowUnknownOption()
     })
 }
 
 export const createViaCommander = (config: ViaConfig, currentProjectName: ProjectName | null) => {
   const viaCommander = new Commander('v')
-
-  viaCommander.version('0.0.1')
+  // handle version output manually only on top level
+  // do not use .version() of commander.js because it could cause errors with
+  // action commands where arguments and options are getting passed through
+  viaCommander
+    .option('-V, --version', 'output the version of via')
+    .action((cmd, args: string[]) => {
+      const options = cmd.opts()
+      // if arguments are passed in here, the arguments does not match any other command
+      // in this case we just print the help text
+      if (args.length === 0 && 'version' in options && options.version === undefined) {
+        console.log('0.0.1', options);
+      } else {
+        cmd._helpAndError()
+      }
+    })
 
   viaCommander
     .command('init <Project>')

--- a/src/cliCommander.ts
+++ b/src/cliCommander.ts
@@ -72,7 +72,7 @@ export const createViaCommander = (config: ViaConfig, currentProjectName: Projec
   // action commands where arguments and options are getting passed through
   viaCommander
     .option('-V, --version', 'output the version of via')
-    .action((cmd, args: string[]) => {
+    .action((cmd, args: string[] = []) => {
       const options = cmd.opts()
       // if arguments are passed in here, the arguments does not match any other command
       // in this case we just print the help text

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,4 +1,5 @@
 import { Command as OriginalCommand } from 'https://deno.land/x/cmd@v1.2.0/mod.ts'
+import { process } from 'https://deno.land/x/cmd@v1.2.0/deps.ts'
 
 export class Commander extends OriginalCommand {
     /**
@@ -16,35 +17,113 @@ export class Commander extends OriginalCommand {
     }
 
     /**
-     * @see 
+     * This function overrides the outputHelpIfRequested function
+     * the help options should only be handled if the help option is the first
+     * argument of the current command
+     */
+    _outputHelpIfRequested() {
+        // the help option will only respected if it is the first argument
+        const hasHelpOption = [this._helpLongFlag, this._helpShortFlag].includes(this.args[0])
+        if (hasHelpOption) {
+            this.outputHelp();
+            // (Do not have all displayed text available so only passing placeholder.)
+            this._exit(0, 'commander.helpDisplayed', '(outputHelp)');
+        }
+    }
+
+    /**
+     * no logic was tampered
+     * This function is only overitten because we needed to overide to call the _outputHelpIfRequested
+     * method instead of the original function outputHelpIfRequested
+     */
+    _parseCommand(operands: any, unknown: any) {
+        const parsed = this.parseOptions(unknown);
+        operands = operands.concat(parsed.operands);
+        unknown = parsed.unknown;
+        this.args = operands.concat(unknown);
+
+        if (operands && this._findCommand(operands[0])) {
+            this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
+        } else if (this._lazyHasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
+            if (operands.length === 1) {
+                this.help();
+            } else {
+                this._dispatchSubcommand(operands[1], [], [this._helpLongFlag]);
+            }
+        } else if (this._defaultCommandName) {
+            this._outputHelpIfRequested(); // Run the help for default command from parent rather than passing to default command
+            this._dispatchSubcommand(this._defaultCommandName, operands, unknown);
+        } else {
+            if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
+                // probaby missing subcommand and no handler, user needs help
+                this._helpAndError();
+            }
+
+            this._outputHelpIfRequested();
+            this._checkForMissingMandatoryOptions();
+            if (parsed.unknown.length > 0) {
+                this.unknownOption(parsed.unknown[0]);
+            }
+
+            if (this._actionHandler) {
+                const args: any[] = this.args.slice();
+                this._args.forEach((arg: any, i: number) => {
+                    if (arg.required && args[i] == null) {
+                        this.missingArgument(arg.name);
+                    } else if (arg.variadic) {
+                        args[i] = args.splice(i);
+                    }
+                });
+
+                this._actionHandler(args);
+                this.emit('command:' + this.name(), operands, unknown);
+            } else if (operands.length) {
+                if (this._findCommand('*')) {
+                    this._dispatchSubcommand('*', operands, unknown);
+                } else if (this.listenerCount('command:*')) {
+                    this.emit('command:*', operands, unknown);
+                } else if (this.commands.length) {
+                    this.unknownCommand();
+                }
+            } else if (this.commands.length) {
+                // This command has subcommands and nothing hooked up at this level, so display help.
+                this._helpAndError();
+            } else {
+                // fall through for caller to handle after calling .parse()
+            }
+        }
+    }
+
+    /**
+     * @see https://github.com/tj/commander.js/issues/764
      */
     public forwardSubcommands() {
-        const listener = ( args: string[], unknown: string[]) => {
+        const listener = (args: string[], unknown: string[]) => {
             // Parse any so-far unknown options
             args = args || [];
             unknown = unknown || [];
 
-            const parsed = this.parseOptions( unknown );
-            if( parsed.args.length ) args = parsed.args.concat( args );
+            const parsed = this.parseOptions(unknown);
+            if (parsed.args.length) args = parsed.args.concat(args);
             unknown = parsed.unknown;
 
             // Output help if necessary
-            if( unknown.includes( '--help' ) || unknown.includes( '-h' ) ){
+            if (unknown.includes('--help') || unknown.includes('-h')) {
                 this.outputHelp();
-                process.exit( 0 );
+                process.exit(0);
             }
 
-            this.parseArgs( args, unknown );
+            this.parseArgs(args, unknown);
         };
 
-        if( this._args.length > 0 ){
-            console.error( 'forwardSubcommands cannot be applied to command with explicit args' );
+        if (this._args.length > 0) {
+            console.error('forwardSubcommands cannot be applied to command with explicit args');
         }
 
         const parent = this.parent || this;
         const name = parent === this ? '*' : this._name;
-        parent.on( 'command:' + name, listener );
-        if( this._alias ) parent.on( 'command:' + this._alias, listener );
+        parent.on('command:' + name, listener);
+        if (this._alias) parent.on('command:' + this._alias, listener);
         return this;
     }
 }

--- a/src/commands/runAction.ts
+++ b/src/commands/runAction.ts
@@ -1,8 +1,9 @@
+import { Commander } from "../commander.ts";
 import { ServiceConfig } from "../config.ts";
 import { runCommand } from "../runCommand.ts";
 
 export const runAction = (actionCommand: string, serviceConfig: ServiceConfig) => {
-    return () => {
-        return runCommand(actionCommand, serviceConfig.path)
+    return (_commander: Commander, commandArgs: string[]) => {
+        return runCommand(actionCommand, serviceConfig.path, commandArgs)
     }
 }

--- a/src/runCommand.ts
+++ b/src/runCommand.ts
@@ -1,7 +1,9 @@
-export async function runCommand(cmd: string, cwd: string) {
+export async function runCommand(cmd: string, cwd: string, args: string[] = []) {
   console.log(`Running ${cmd} in ${cwd}`)
   const p = Deno.run({
-    cmd: ['sh', '-c', cmd],
+    // pass an empty string before the args to pass the args as args ($1 $2 $3 .../ $@ and not as $0)
+    // the empty string is accessible at $0
+    cmd: ['sh', '-c', cmd, '', ...args ],
     cwd,
   });
   await p.status()


### PR DESCRIPTION
It shouldnt be necessary to review the largest function `_parseCommand` because I copied it from the original Command class. (what a pity they didn't created  the `outputHelpIfRequested` function to the class as well. Than I could have done it without copying so much)

The main reason for requesting feedback is if I don't have missed or brook something and if you are ok with it how it does work.

What is different now:
* `-h --help` is now only possible if it is the first argument of a command. If its not the Option will be ignored (so it can be passed to the actions command)
* `-V --version` is handled by ourselves to only print the version number if no other commands/arguments got passed (for the same reason: to pass -V --version to the actions command as arguments)
* Now all Arguments/Options after a Action-Command will be bassed as shell arguments. So now it is possible to create more advanced and flexible actions.


### Example setup for passing through the args

```yaml
services:
  svc:
    path: xxx
    actions:
      npm: npm $@ # $@ passes all the arguments npm command
      create-branch: git checkout -b feature/$1 # $1 ... $[x] can be used as well to for placing single arguments to specific position in the final command
      exec: $@
```

Example Commands
```
via svc npm install foobar
via svc npm ls
via svc create-branch foobar 
via svc exec via --help # ;P
```

PS: I think I will create a more advanced example config which also demonstrates how to use this feature. If you have good reallife examples, feel free to mention them here.